### PR TITLE
Declare roman conversion array as a constant

### DIFF
--- a/src/PiggyCustomEnchants/Main.php
+++ b/src/PiggyCustomEnchants/Main.php
@@ -31,6 +31,22 @@ class Main extends PluginBase
     const NOT_COMPATIBLE = 1;
     const NOT_COMPATIBLE_WITH_OTHER_ENCHANT = 2;
 
+    const ROMAN_CONVERSION_TABLE = [
+        'M' => 1000,
+        'CM' => 900,
+        'D' => 500,
+        'CD' => 400,
+        'C' => 100,
+        'XC' => 90,
+        'L' => 50,
+        'XL' => 40,
+        'X' => 10,
+        'IX' => 9,
+        'V' => 5,
+        'IV' => 4,
+        'I' => 1
+    ];
+
     public $vampirecd;
     public $cloakingcd;
     public $berserkercd;
@@ -457,18 +473,17 @@ class Main extends PluginBase
      */
     public function getRomanNumber($integer) //Thank you @Muqsit!
     {
-        $table = array('M' => 1000, 'CM' => 900, 'D' => 500, 'CD' => 400, 'C' => 100, 'XC' => 90, 'L' => 50, 'XL' => 40, 'X' => 10, 'IX' => 9, 'V' => 5, 'IV' => 4, 'I' => 1);
-        $return = '';
+        $romanString = "";
         while ($integer > 0) {
-            foreach ($table as $rom => $arb) {
+            foreach (self::ROMAN_CONVERSION_TABLE as $rom => $arb) {
                 if ($integer >= $arb) {
                     $integer -= $arb;
-                    $return .= $rom;
+                    $romanString .= $rom;
                     break;
                 }
             }
         }
-        return $return;
+        return $romanString;
     }
 
     public function getRarityColor($rarity)


### PR DESCRIPTION
<!-- DO NOT REMOVE THIS:
failing to complete the required fields will result in the issue being closed due to insufficient information.
-->
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] ***PLEASE*** don't use the GitHub Web Editor
- * [x] Have a detailed title like "Fix CustomEnchants::getName() must be..."

#### **What does the PR change?**
<!-- Does your Pull Request fix a bug? Enhancements the plugin? -->
Declares roman conversion array as a constant. It rather be a constant if it isn't going to be modified at all.
#### **Testing Environment**
<!-- PHP and OS version required, pmmp build link required. -->
_Currently untested._
- PHP: 
- PMMP:
- OS:

#### **Extra Information**
<!-- Anything else we should know? -->
