### PR TITLE
Resolve Compatibility Issues with PureEntitiesX

### DIFF
--- a/src/PiggyCustomEnchants/Entities/Fireball.php
+++ b/src/PiggyCustomEnchants/Entities/Fireball.php
@@ -20,7 +20,7 @@ class Fireball extends PiggyProjectile
     protected $damage = 5;
 
     /**
-     * Used to replace const NETWORKD_ID to resolve registration conflicts with vanilla entities
+     * Used to replace const NETWORK_ID to resolve registration conflicts with vanilla entities
      * @var int
      */
     const TYPE_ID = 94;

--- a/src/PiggyCustomEnchants/Entities/Fireball.php
+++ b/src/PiggyCustomEnchants/Entities/Fireball.php
@@ -19,7 +19,11 @@ class Fireball extends PiggyProjectile
 
     protected $damage = 5;
 
-    const NETWORK_ID = 94;
+    /**
+     * Used to replace const NETWORKD_ID to resolve registration conflicts with vanilla entities
+     * @var int
+     */
+    const TYPE_ID = 94;
 
     /**
      * @param Entity $entity

--- a/src/PiggyCustomEnchants/Entities/Lightning.php
+++ b/src/PiggyCustomEnchants/Entities/Lightning.php
@@ -9,6 +9,8 @@ use pocketmine\entity\Living;
 use pocketmine\event\entity\EntityCombustByEntityEvent;
 use pocketmine\event\entity\EntityDamageByEntityEvent;
 use pocketmine\event\entity\EntityDamageEvent;
+use pocketmine\network\mcpe\protocol\AddEntityPacket;
+use pocketmine\Player;
 
 /**
  * Class Lightning
@@ -20,7 +22,11 @@ class Lightning extends Entity
     public $length = 0.9;
     public $height = 1.8;
 
-    const NETWORK_ID = 93;
+    /**
+     * Used to replace const NETWORK_ID to resolve registration conflicts with vanilla entities
+     * @var int
+     */
+    const TYPE_ID = 93;
 
     /**
      * @param int $tickDiff
@@ -53,5 +59,18 @@ class Lightning extends Entity
             $this->flagForDespawn();
         }
         return $hasUpdate;
+    }
+    /**
+     * @param Player $player
+     */
+    public function spawnTo(Player $player): void
+    {
+        $pk = new AddEntityPacket();
+        $pk->entityRuntimeId = $this->getId();
+        $pk->type = static::TYPE_ID;
+        $pk->position = $this->asVector3();
+        $pk->motion = $this->getMotion();
+        $pk->metadata = $this->propertyManager->getAll();
+        $player->dataPacket($pk);
     }
 }

--- a/src/PiggyCustomEnchants/Entities/PigProjectile.php
+++ b/src/PiggyCustomEnchants/Entities/PigProjectile.php
@@ -26,7 +26,11 @@ class PigProjectile extends PiggyProjectile
 
     protected $damage = 1.5;
 
-    const NETWORK_ID = 12;
+    /**
+     * Used to replace const NETWORK_ID to resolve registration conflicts with vanilla entities
+     * @var int
+     */
+    const TYPE_ID = 12;
 
     const PORKLEVELS = [
         //level => [damage, dinnerbone, zombie, drop id, drop name]
@@ -95,7 +99,7 @@ class PigProjectile extends PiggyProjectile
     protected function sendSpawnPacket(Player $player): void
     {
         $pk = new AddEntityPacket();
-        $pk->type = $this->isZombie() ? Entity::ZOMBIE_PIGMAN : PigProjectile::NETWORK_ID;
+        $pk->type = $this->isZombie() ? Entity::ZOMBIE_PIGMAN : static::TYPE_ID;
         $pk->entityRuntimeId = $this->getId();
         $pk->position = $this->asVector3();
         $pk->motion = $this->getMotion();

--- a/src/PiggyCustomEnchants/Entities/PigProjectile.php
+++ b/src/PiggyCustomEnchants/Entities/PigProjectile.php
@@ -99,7 +99,7 @@ class PigProjectile extends PiggyProjectile
         $pk->entityRuntimeId = $this->getId();
         $pk->position = $this->asVector3();
         $pk->motion = $this->getMotion();
-        $pk->metadata = $this->dataProperties;
+        $pk->metadata = $this->getDataPropertyManager()->getAll();
         $player->dataPacket($pk);
     }
 

--- a/src/PiggyCustomEnchants/Entities/PigProjectile.php
+++ b/src/PiggyCustomEnchants/Entities/PigProjectile.php
@@ -99,7 +99,7 @@ class PigProjectile extends PiggyProjectile
         $pk->entityRuntimeId = $this->getId();
         $pk->position = $this->asVector3();
         $pk->motion = $this->getMotion();
-        $pk->metadata = $this->getDataPropertyManager()->getAll();
+        $pk->metadata = $this->propertyManager->getAll();
         $player->dataPacket($pk);
     }
 

--- a/src/PiggyCustomEnchants/Entities/PiggyProjectile.php
+++ b/src/PiggyCustomEnchants/Entities/PiggyProjectile.php
@@ -20,7 +20,7 @@ class PiggyProjectile extends Projectile
     private $ownerOriginalLocation;
 
     /**
-     * Used to replace const NETWORKD_ID to resolve registration conflicts with vanilla entities
+     * Used to replace const NETWORK_ID to resolve registration conflicts with vanilla entities
      * @var int
      */
     const TYPE_ID = 0;

--- a/src/PiggyCustomEnchants/Entities/PiggyProjectile.php
+++ b/src/PiggyCustomEnchants/Entities/PiggyProjectile.php
@@ -7,6 +7,7 @@ use pocketmine\entity\Entity;
 use pocketmine\entity\projectile\Projectile;
 use pocketmine\level\Level;
 use pocketmine\nbt\tag\CompoundTag;
+use pocketmine\network\mcpe\protocol\AddEntityPacket;
 use pocketmine\Player;
 
 /**
@@ -17,6 +18,12 @@ class PiggyProjectile extends Projectile
 {
     public $placeholder;
     private $ownerOriginalLocation;
+
+    /**
+     * Used to replace const NETWORKD_ID to resolve registration conflicts with vanilla entities
+     * @var int
+     */
+    const TYPE_ID = 0;
 
     /**
      * PiggyProjectile constructor.
@@ -52,5 +59,21 @@ class PiggyProjectile extends Projectile
             $hasUpdate = true;
         }
         return $hasUpdate;
+    }
+    /**
+     * @param Player $player
+     */
+    public function spawnTo(Player $player): void
+    {
+        parent::spawnTo($player);
+        $pk = new AddEntityPacket();
+        $pk->entityRuntimeId = $this->getId();
+        $pk->type = static::TYPE_ID;
+        $pk->position =$this->asVector3();
+        $pk->motion = $this->getMotion();
+        $pk->yaw = $this->yaw;
+        $pk->pitch = $this->pitch;
+        $pk->metadata = $this->propertyManager->getAll();
+        $player->dataPacket($pk);
     }
 }

--- a/src/PiggyCustomEnchants/Entities/WitherSkull.php
+++ b/src/PiggyCustomEnchants/Entities/WitherSkull.php
@@ -6,14 +6,13 @@ namespace PiggyCustomEnchants\Entities;
 use pocketmine\entity\Effect;
 use pocketmine\entity\Entity;
 use pocketmine\entity\Living;
-use pocketmine\entity\projectile\Projectile;
 use pocketmine\event\entity\ProjectileHitEvent;
 
 /**
  * Class WitherSkull
  * @package PiggyCustomEnchants\Entities
  */
-class WitherSkull extends Projectile
+class WitherSkull extends PiggyProjectile
 {
     public $width = 0.5;
     public $length = 0.5;
@@ -24,7 +23,11 @@ class WitherSkull extends Projectile
 
     protected $damage = 0;
 
-    const NETWORK_ID = 89;
+    /**
+     * Used to replace const NETWORK_ID to resolve registration conflicts with vanilla entities
+     * @var int
+     */
+    const TYPE_ID = 89;
 
     /**
      * @param Entity $entity

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -1022,40 +1022,9 @@ class EventListener implements Listener
                     if ($enchantment !== null) {
                         if ($event->getDamage() >= $entity->getHealth()) {
                             if ($enchantment->getLevel() > 1) {
-                                switch($slot){
-                                    case ArmorInventory::SLOT_CHEST:
-                                        $entity->getArmorInventory()->setChestplate($this->plugin->addEnchantment($armor, $enchantment->getId(), $enchantment->getLevel() - 1));
-                                        break;
-                                    case ArmorInventory::SLOT_FEET:
-                                        $entity->getArmorInventory()->setBoots($this->plugin->addEnchantment($armor, $enchantment->getId(), $enchantment->getLevel() - 1));
-                                        break;
-                                    case ArmorInventory::SLOT_HEAD:
-                                        $entity->getArmorInventory()->setHelmet($this->plugin->addEnchantment($armor, $enchantment->getId(), $enchantment->getLevel() - 1));
-                                        break;
-                                    case ArmorInventory::SLOT_LEGS:
-                                        $entity->getArmorInventory()->setChestplate($this->plugin->addEnchantment($armor, $enchantment->getId(), $enchantment->getLevel() - 1));
-                                        break;
-                                    default:
-                                        $this->plugin->getLogger()->error("CheckArmorEnchants: Slot $slot not found in ArmorInventory");
-                                }
-
+                                $entity->getArmorInventory()->setItem($slot,$this->plugin->addEnchantment($armor, $enchantment->getId(), $enchantment->getLevel() - 1));
                             }else{
-                                switch($slot){
-                                    case ArmorInventory::SLOT_CHEST:
-                                        $entity->getArmorInventory()->setChestplate($this->plugin->removeEnchantment($armor, $enchantment));
-                                        break;
-                                    case ArmorInventory::SLOT_FEET:
-                                        $entity->getArmorInventory()->setBoots($this->plugin->removeEnchantment($armor, $enchantment));
-                                        break;
-                                    case ArmorInventory::SLOT_HEAD:
-                                        $entity->getArmorInventory()->setHelmet($this->plugin->removeEnchantment($armor, $enchantment));
-                                        break;
-                                    case ArmorInventory::SLOT_LEGS:
-                                        $entity->getArmorInventory()->setChestplate($this->plugin->removeEnchantment($armor, $enchantment));
-                                        break;
-                                    default:
-                                        $this->plugin->getLogger()->error("CheckArmorEnchants: Slot $slot not found in ArmorInventory");
-                                }
+                                $entity->getArmorInventory()->setItem($slot, $this->plugin->removeEnchantment($armor, $enchantment));
                             }
                             $entity->removeAllEffects();
                             $entity->setHealth($entity->getMaxHealth());
@@ -1127,120 +1096,121 @@ class EventListener implements Listener
                     }
                 }
                 if ($event instanceof EntityDamageByEntityEvent) {
+                    /**
+                     * @var $damager Player
+                     */
                     $damager = $event->getDamager();
-                    if ($damager instanceof Living) {
-                        foreach ($entity->getArmorInventory()->getContents() as $slot => $armor) {
-                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::MOLTEN);
-                            if ($enchantment !== null) {
-                                $this->plugin->getServer()->getScheduler()->scheduleDelayedTask(new MoltenTask($this->plugin, $damager, $enchantment->getLevel()), 1);
-                            }
-                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::ENLIGHTED);
-                            if ($enchantment !== null && $entity->hasEffect(Effect::REGENERATION) !== true) {
-                                $effect = Effect::getEffect(Effect::REGENERATION);
-                                $effect->setAmplifier($enchantment->getLevel());
-                                $effect->setDuration(60 * $enchantment->getLevel());
-                                $effect->setVisible(false);
-                                $entity->addEffect($effect);
-                            }
-                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::HARDENED);
-                            if ($enchantment !== null && $damager->hasEffect(Effect::WEAKNESS) !== true) {
-                                $effect = Effect::getEffect(Effect::WEAKNESS);
-                                $effect->setAmplifier($enchantment->getLevel());
-                                $effect->setDuration(60 * $enchantment->getLevel());
-                                $effect->setVisible(false);
-                                $damager->addEffect($effect);
-                            }
-                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::POISONED);
-                            if ($enchantment !== null && $damager->hasEffect(Effect::POISON) !== true) {
-                                $effect = Effect::getEffect(Effect::POISON);
-                                $effect->setAmplifier($enchantment->getLevel());
-                                $effect->setDuration(60 * $enchantment->getLevel());
-                                $effect->setVisible(false);
-                                $damager->addEffect($effect);
-                            }
-                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::FROZEN);
-                            if ($enchantment !== null && $damager->hasEffect(Effect::SLOWNESS) !== true) {
+                    foreach ($entity->getArmorInventory()->getContents() as $slot => $armor) {
+                        $enchantment = $armor->getEnchantment(CustomEnchantsIds::MOLTEN);
+                        if ($enchantment !== null) {
+                            $this->plugin->getServer()->getScheduler()->scheduleDelayedTask(new MoltenTask($this->plugin, $damager, $enchantment->getLevel()), 1);
+                        }
+                        $enchantment = $armor->getEnchantment(CustomEnchantsIds::ENLIGHTED);
+                        if ($enchantment !== null && $entity->hasEffect(Effect::REGENERATION) !== true) {
+                            $effect = Effect::getEffect(Effect::REGENERATION);
+                            $effect->setAmplifier($enchantment->getLevel());
+                            $effect->setDuration(60 * $enchantment->getLevel());
+                            $effect->setVisible(false);
+                            $entity->addEffect($effect);
+                        }
+                        $enchantment = $armor->getEnchantment(CustomEnchantsIds::HARDENED);
+                        if ($enchantment !== null && $damager->hasEffect(Effect::WEAKNESS) !== true) {
+                            $effect = Effect::getEffect(Effect::WEAKNESS);
+                            $effect->setAmplifier($enchantment->getLevel());
+                            $effect->setDuration(60 * $enchantment->getLevel());
+                            $effect->setVisible(false);
+                            $damager->addEffect($effect);
+                        }
+                        $enchantment = $armor->getEnchantment(CustomEnchantsIds::POISONED);
+                        if ($enchantment !== null && $damager->hasEffect(Effect::POISON) !== true) {
+                            $effect = Effect::getEffect(Effect::POISON);
+                            $effect->setAmplifier($enchantment->getLevel());
+                            $effect->setDuration(60 * $enchantment->getLevel());
+                            $effect->setVisible(false);
+                            $damager->addEffect($effect);
+                        }
+                        $enchantment = $armor->getEnchantment(CustomEnchantsIds::FROZEN);
+                        if ($enchantment !== null && $damager->hasEffect(Effect::SLOWNESS) !== true) {
+                            $effect = Effect::getEffect(Effect::SLOWNESS);
+                            $effect->setAmplifier($enchantment->getLevel());
+                            $effect->setDuration(60 * $enchantment->getLevel());
+                            $effect->setVisible(false);
+                            $damager->addEffect($effect);
+                        }
+                        $enchantment = $armor->getEnchantment(CustomEnchantsIds::REVULSION);
+                        if ($enchantment !== null && $damager->hasEffect(Effect::NAUSEA) !== true) {
+                            $effect = Effect::getEffect(Effect::NAUSEA);
+                            $effect->setAmplifier(0);
+                            $effect->setDuration(20 * $enchantment->getLevel());
+                            $effect->setVisible(false);
+                            $damager->addEffect($effect);
+                        }
+                        $enchantment = $armor->getEnchantment(CustomEnchantsIds::CURSED);
+                        if ($enchantment !== null && $damager->hasEffect(Effect::WITHER) !== true) {
+                            $effect = Effect::getEffect(Effect::WITHER);
+                            $effect->setAmplifier($enchantment->getLevel());
+                            $effect->setDuration(60 * $enchantment->getLevel());
+                            $effect->setVisible(false);
+                            $damager->addEffect($effect);
+                        }
+                        $enchantment = $armor->getEnchantment(CustomEnchantsIds::DRUNK);
+                        if ($enchantment !== null) {
+                            if (!$damager->hasEffect(Effect::SLOWNESS)) {
                                 $effect = Effect::getEffect(Effect::SLOWNESS);
                                 $effect->setAmplifier($enchantment->getLevel());
                                 $effect->setDuration(60 * $enchantment->getLevel());
                                 $effect->setVisible(false);
                                 $damager->addEffect($effect);
                             }
-                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::REVULSION);
-                            if ($enchantment !== null && $damager->hasEffect(Effect::NAUSEA) !== true) {
-                                $effect = Effect::getEffect(Effect::NAUSEA);
-                                $effect->setAmplifier(0);
-                                $effect->setDuration(20 * $enchantment->getLevel());
-                                $effect->setVisible(false);
-                                $damager->addEffect($effect);
-                            }
-                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::CURSED);
-                            if ($enchantment !== null && $damager->hasEffect(Effect::WITHER) !== true) {
-                                $effect = Effect::getEffect(Effect::WITHER);
+                            if (!$damager->hasEffect(Effect::MINING_FATIGUE)) {
+                                $effect = Effect::getEffect(Effect::MINING_FATIGUE);
                                 $effect->setAmplifier($enchantment->getLevel());
                                 $effect->setDuration(60 * $enchantment->getLevel());
                                 $effect->setVisible(false);
                                 $damager->addEffect($effect);
                             }
-                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::DRUNK);
+                            if (!$damager->hasEffect(Effect::NAUSEA)) {
+                                $effect = Effect::getEffect(Effect::NAUSEA);
+                                $effect->setAmplifier(0);
+                                $effect->setDuration(60 * $enchantment->getLevel());
+                                $effect->setVisible(false);
+                                $damager->addEffect($effect);
+                            }
+                        }
+                        $enchantment = $armor->getEnchantment(CustomEnchantsIds::CLOAKING);
+                        if ($enchantment !== null) {
+                            if ((!isset($this->plugin->cloakingcd[$entity->getLowerCaseName()]) || time() > $this->plugin->cloakingcd[$entity->getLowerCaseName()]) && $entity->hasEffect(Effect::INVISIBILITY)) {
+                                $this->plugin->cloakingcd[$entity->getLowerCaseName()] = time() + 10;
+                                $effect = Effect::getEffect(Effect::INVISIBILITY);
+                                $effect->setAmplifier(0);
+                                $effect->setDuration(60 * $enchantment->getLevel());
+                                $effect->setVisible(false);
+                                $entity->addEffect($effect);
+                                $entity->sendMessage(TextFormat::DARK_GRAY . "You have become invisible!");
+                            }
+                        }
+                        $enchantment = $armor->getEnchantment(CustomEnchantsIds::ANTIKNOCKBACK);
+                        if ($enchantment !== null) {
+                            $event->setKnockBack($event->getKnockBack() - ($event->getKnockBack() / $antikb));
+                            $antikb--;
+                        }
+                        if ($damager instanceof Player) {
+                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::ARMORED);
                             if ($enchantment !== null) {
-                                if (!$damager->hasEffect(Effect::SLOWNESS)) {
-                                    $effect = Effect::getEffect(Effect::SLOWNESS);
-                                    $effect->setAmplifier($enchantment->getLevel());
-                                    $effect->setDuration(60 * $enchantment->getLevel());
-                                    $effect->setVisible(false);
-                                    $damager->addEffect($effect);
-                                }
-                                if (!$damager->hasEffect(Effect::MINING_FATIGUE)) {
-                                    $effect = Effect::getEffect(Effect::MINING_FATIGUE);
-                                    $effect->setAmplifier($enchantment->getLevel());
-                                    $effect->setDuration(60 * $enchantment->getLevel());
-                                    $effect->setVisible(false);
-                                    $damager->addEffect($effect);
-                                }
-                                if (!$damager->hasEffect(Effect::NAUSEA)) {
-                                    $effect = Effect::getEffect(Effect::NAUSEA);
-                                    $effect->setAmplifier(0);
-                                    $effect->setDuration(60 * $enchantment->getLevel());
-                                    $effect->setVisible(false);
-                                    $damager->addEffect($effect);
+                                if ($damager->getInventory()->getItemInHand()->isSword()) {
+                                    $event->setDamage($damage - ($damage * 0.2 * $enchantment->getLevel()));
                                 }
                             }
-                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::CLOAKING);
+                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::TANK);
                             if ($enchantment !== null) {
-                                if ((!isset($this->plugin->cloakingcd[$entity->getLowerCaseName()]) || time() > $this->plugin->cloakingcd[$entity->getLowerCaseName()]) && $entity->hasEffect(Effect::INVISIBILITY)) {
-                                    $this->plugin->cloakingcd[$entity->getLowerCaseName()] = time() + 10;
-                                    $effect = Effect::getEffect(Effect::INVISIBILITY);
-                                    $effect->setAmplifier(0);
-                                    $effect->setDuration(60 * $enchantment->getLevel());
-                                    $effect->setVisible(false);
-                                    $entity->addEffect($effect);
-                                    $entity->sendMessage(TextFormat::DARK_GRAY . "You have become invisible!");
+                                if ($damager->getInventory()->getItemInHand()->isAxe()) {
+                                    $event->setDamage($damage - ($damage * 0.2 * $enchantment->getLevel()));
                                 }
                             }
-                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::ANTIKNOCKBACK);
+                            $enchantment = $armor->getEnchantment(CustomEnchantsIds::HEAVY);
                             if ($enchantment !== null) {
-                                $event->setKnockBack($event->getKnockBack() - ($event->getKnockBack() / $antikb));
-                                $antikb--;
-                            }
-                            if ($damager instanceof Player) {
-                                $enchantment = $armor->getEnchantment(CustomEnchantsIds::ARMORED);
-                                if ($enchantment !== null) {
-                                    if ($damager->getInventory()->getItemInHand()->isSword()) {
-                                        $event->setDamage($damage - ($damage * 0.2 * $enchantment->getLevel()));
-                                    }
-                                }
-                                $enchantment = $armor->getEnchantment(CustomEnchantsIds::TANK);
-                                if ($enchantment !== null) {
-                                    if ($damager->getInventory()->getItemInHand()->isAxe()) {
-                                        $event->setDamage($damage - ($damage * 0.2 * $enchantment->getLevel()));
-                                    }
-                                }
-                                $enchantment = $armor->getEnchantment(CustomEnchantsIds::HEAVY);
-                                if ($enchantment !== null) {
-                                    if ($damager->getInventory()->getItemInHand()->getId() == Item::BOW) {
-                                        $event->setDamage($damage - ($damage * 0.2 * $enchantment->getLevel()));
-                                    }
+                                if ($damager->getInventory()->getItemInHand()->getId() == Item::BOW) {
+                                    $event->setDamage($damage - ($damage * 0.2 * $enchantment->getLevel()));
                                 }
                             }
                         }

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -1100,9 +1100,6 @@ class EventListener implements Listener
                     }
                 }
                 if ($event instanceof EntityDamageByEntityEvent) {
-                    /**
-                     * @var $damager Player
-                     */
                     $damager = $event->getDamager();
                     foreach ($entity->getArmorInventory()->getContents() as $slot => $armor) {
                         $enchantment = $armor->getEnchantment(CustomEnchantsIds::MOLTEN);

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -440,9 +440,6 @@ class EventListener implements Listener
                     $entity->addEffect($effect);
                 }
             }
-            /**
-             * @var $entity Entity|null
-             */
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::LIFESTEAL);
             if ($enchantment !== null) {
                 if ($damager->getHealth() + 2 + $enchantment->getLevel() <= $damager->getMaxHealth()) {

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -4,9 +4,7 @@ namespace PiggyCustomEnchants;
 
 use PiggyCustomEnchants\CustomEnchants\CustomEnchantsIds;
 use PiggyCustomEnchants\Entities\Fireball;
-use PiggyCustomEnchants\Entities\Lightning;
 use PiggyCustomEnchants\Entities\PigProjectile;
-use PiggyCustomEnchants\Entities\VolleyArrow;
 use PiggyCustomEnchants\Entities\WitherSkull;
 use PiggyCustomEnchants\Tasks\GoeyTask;
 use PiggyCustomEnchants\Tasks\GrapplingTask;

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -396,7 +396,53 @@ class EventListener implements Listener
     public function checkGlobalEnchants(Player $damager, Entity $entity = null, Event $event)
     {
         //TODO: Check to make sure you can use enchant with item
-        if ($event instanceof EntityDamageEvent and $entity instanceof Living) {
+        if ($event instanceof EntityDamageEvent) {
+            if($entity instanceof Living){
+                $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::BLIND);
+                if ($enchantment !== null && $entity->hasEffect(Effect::BLINDNESS) !== true) {
+                    $effect = Effect::getEffect(Effect::BLINDNESS);
+                    $effect->setAmplifier(0);
+                    $effect->setDuration(100 + 20 * $enchantment->getLevel());
+                    $effect->setVisible(false);
+                    $entity->addEffect($effect);
+                }
+                $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::POISON);
+                if ($enchantment !== null && $entity->hasEffect(Effect::POISON) !== true) {
+                    $effect = Effect::getEffect(Effect::POISON);
+                    $effect->setAmplifier($enchantment->getLevel());
+                    $effect->setDuration(60 * $enchantment->getLevel());
+                    $effect->setVisible(false);
+                    $entity->addEffect($effect);
+                }
+                $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::CRIPPLINGSTRIKE);
+                if ($enchantment !== null) {
+                    if (!$entity->hasEffect(Effect::NAUSEA)) {
+                        $effect = Effect::getEffect(Effect::NAUSEA);
+                        $effect->setAmplifier(0);
+                        $effect->setDuration(100 * $enchantment->getLevel());
+                        $effect->setVisible(false);
+                        $entity->addEffect($effect);
+                    }
+                    if (!$entity->hasEffect(Effect::SLOWNESS)) {
+                        $effect = Effect::getEffect(Effect::SLOWNESS);
+                        $effect->setAmplifier($enchantment->getLevel());
+                        $effect->setDuration(100 * $enchantment->getLevel());
+                        $effect->setVisible(false);
+                        $entity->addEffect($effect);
+                    }
+                }
+                $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::WITHER);
+                if ($enchantment !== null && $entity->hasEffect(Effect::WITHER) !== true) {
+                    $effect = Effect::getEffect(Effect::WITHER);
+                    $effect->setAmplifier($enchantment->getLevel());
+                    $effect->setDuration(60 * $enchantment->getLevel());
+                    $effect->setVisible(false);
+                    $entity->addEffect($effect);
+                }
+            }
+            /**
+             * @var $entity Entity|null
+             */
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::LIFESTEAL);
             if ($enchantment !== null) {
                 if ($damager->getHealth() + 2 + $enchantment->getLevel() <= $damager->getMaxHealth()) {
@@ -404,14 +450,6 @@ class EventListener implements Listener
                 } else {
                     $damager->setHealth($damager->getMaxHealth());
                 }
-            }
-            $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::BLIND);
-            if ($enchantment !== null && $entity->hasEffect(Effect::BLINDNESS) !== true) {
-                $effect = Effect::getEffect(Effect::BLINDNESS);
-                $effect->setAmplifier(0);
-                $effect->setDuration(100 + 20 * $enchantment->getLevel());
-                $effect->setVisible(false);
-                $entity->addEffect($effect);
             }
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::DEATHBRINGER);
             if ($enchantment !== null) {
@@ -422,31 +460,6 @@ class EventListener implements Listener
             if ($enchantment !== null) {
                 $task = new GoeyTask($this->plugin, $entity, $enchantment->getLevel());
                 $this->plugin->getServer()->getScheduler()->scheduleDelayedTask($task, 1);
-            }
-            $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::POISON);
-            if ($enchantment !== null && $entity->hasEffect(Effect::POISON) !== true) {
-                $effect = Effect::getEffect(Effect::POISON);
-                $effect->setAmplifier($enchantment->getLevel());
-                $effect->setDuration(60 * $enchantment->getLevel());
-                $effect->setVisible(false);
-                $entity->addEffect($effect);
-            }
-            $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::CRIPPLINGSTRIKE);
-            if ($enchantment !== null) {
-                if (!$entity->hasEffect(Effect::NAUSEA)) {
-                    $effect = Effect::getEffect(Effect::NAUSEA);
-                    $effect->setAmplifier(0);
-                    $effect->setDuration(100 * $enchantment->getLevel());
-                    $effect->setVisible(false);
-                    $entity->addEffect($effect);
-                }
-                if (!$entity->hasEffect(Effect::SLOWNESS)) {
-                    $effect = Effect::getEffect(Effect::SLOWNESS);
-                    $effect->setAmplifier($enchantment->getLevel());
-                    $effect->setDuration(100 * $enchantment->getLevel());
-                    $effect->setVisible(false);
-                    $entity->addEffect($effect);
-                }
             }
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::VAMPIRE);
             if ($enchantment !== null) {
@@ -475,14 +488,6 @@ class EventListener implements Listener
                 if (!$damager->isOnGround()) {
                     $event->setDamage($event->getDamage() * (1 + 0.10 * $enchantment->getLevel()));
                 }
-            }
-            $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::WITHER);
-            if ($enchantment !== null && $entity->hasEffect(Effect::WITHER) !== true) {
-                $effect = Effect::getEffect(Effect::WITHER);
-                $effect->setAmplifier($enchantment->getLevel());
-                $effect->setDuration(60 * $enchantment->getLevel());
-                $effect->setVisible(false);
-                $entity->addEffect($effect);
             }
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::DISARMING);
             if ($enchantment !== null) {
@@ -544,7 +549,7 @@ class EventListener implements Listener
                 $chance = 10 * $enchantment->getLevel();
                 $random = mt_rand(0, 100);
                 if ($random <= $chance) {
-                    $lightning = new Lightning($entity->getLevel(), Entity::createBaseNBT($entity));
+                    $lightning = Entity::createEntity("Lightning", $entity->getLevel(), Entity::createBaseNBT($entity));
                     $lightning->setOwningEntity($damager);
                     $lightning->spawnToAll();
                 }
@@ -879,7 +884,7 @@ class EventListener implements Listener
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::PLACEHOLDER);
             if ($enchantment !== null) {
                 $nbt = Entity::createBaseNBT($entity, $damager->getDirectionVector(), $entity->yaw, $entity->pitch);
-                $newentity = new VolleyArrow($damager->getLevel(), $nbt, $damager, $entity->isCritical(), true, false);
+                $newentity = Entity::createEntity("VolleyArrow", $damager->getLevel(), $nbt, $damager, $entity->isCritical(), true, false);
                 $newentity->setMotion($newentity->getMotion()->multiply($event->getForce()));
                 $newentity->spawnToAll();
                 $entity->close();
@@ -888,7 +893,7 @@ class EventListener implements Listener
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::BLAZE);
             if ($enchantment !== null && $entity instanceof Fireball !== true) {
                 $nbt = Entity::createBaseNBT($entity, $damager->getDirectionVector(), $entity->yaw, $entity->pitch);
-                $fireball = new Fireball($damager->getLevel(), $nbt, $damager, isset($entity->placeholder) ? $entity->placeholder : false);
+                $fireball = Entity::createEntity("Fireball", $damager->getLevel(), $nbt, $damager, isset($entity->placeholder) ? $entity->placeholder : false);
                 $fireball->setMotion($fireball->getMotion()->multiply($event->getForce()));
                 $fireball->spawnToAll();
                 $entity->close();
@@ -897,7 +902,7 @@ class EventListener implements Listener
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::PORKIFIED);
             if ($enchantment !== null && $entity instanceof PigProjectile !== true) {
                 $nbt = Entity::createBaseNBT($entity, $damager->getDirectionVector(), $entity->yaw, $entity->pitch);
-                $pig = new PigProjectile($event->getEntity()->getLevel(), $nbt, $event->getEntity(), isset($entity->placeholder) ? $entity->placeholder : false, $enchantment->getLevel());
+                $pig = Entity::createEntity("PigProjectile", $event->getEntity()->getLevel(), $nbt, $event->getEntity(), isset($entity->placeholder) ? $entity->placeholder : false, $enchantment->getLevel());
                 $pig->setMotion($pig->getMotion()->multiply($event->getForce()));
                 $pig->spawnToAll();
                 $entity->close();
@@ -906,7 +911,7 @@ class EventListener implements Listener
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::WITHERSKULL);
             if ($enchantment !== null && $entity instanceof WitherSkull !== true) {
                 $nbt = Entity::createBaseNBT($entity, $damager->getDirectionVector(), $entity->yaw, $entity->pitch);
-                $skull = new WitherSkull($damager->getLevel(), $nbt, $damager);
+                $skull = Entity::createEntity("WitherSkull", $damager->getLevel(), $nbt, $damager);
                 $skull->setMotion($skull->getMotion()->multiply($event->getForce()));
                 $skull->spawnToAll();
                 $entity->close();
@@ -926,19 +931,19 @@ class EventListener implements Listener
                     $projectile = null;
                     if ($entity instanceof Arrow) {
                         $nbt = Entity::createBaseNBT($damager->add(0, $damager->getEyeHeight()), $damager->getDirectionVector(), $damager->yaw, $damager->pitch);
-                        $projectile = new VolleyArrow($damager->getLevel(), $nbt, $damager, $entity->isCritical(), false, true);
+                        $projectile = Entity::createEntity("VolleyArrow", $damager->getLevel(), $nbt, $damager, $entity->isCritical(), false, true);
                     }
                     if ($entity instanceof Fireball) {
                         $nbt = Entity::createBaseNBT($damager->add(0, $damager->getEyeHeight()), $damager->getDirectionVector(), $damager->yaw, $damager->pitch);
-                        $projectile = new Fireball($damager->getLevel(), $nbt, $damager);
+                        $projectile = Entity::createEntity("Fireball", $damager->getLevel(), $nbt, $damager);
                     }
                     if ($entity instanceof PigProjectile) {
                         $nbt = Entity::createBaseNBT($damager->add(0, $damager->getEyeHeight()), $damager->getDirectionVector(), $damager->yaw, $damager->pitch);
-                        $projectile = new PigProjectile($damager->getLevel(), $nbt, $damager, false, $entity->getPorkLevel());
+                        $projectile = Entity::createEntity("PigProjectile", $damager->getLevel(), $nbt, $damager, false, $entity->getPorkLevel());
                     }
                     if ($entity instanceof WitherSkull) {
                         $nbt = Entity::createBaseNBT($damager->add(0, $damager->getEyeHeight()), $damager->getDirectionVector(), $damager->yaw, $damager->pitch);
-                        $projectile = new WitherSkull($damager->getLevel(), $nbt, $damager);
+                        $projectile = Entity::createEntity("WitherSkull", $damager->getLevel(), $nbt, $damager);
                     }
                     $projectile->setMotion($newDir->normalize()->multiply($entity->getMotion()->multiply($event->getForce())->length()));
                     if ($projectile->isOnFire()) {

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -902,7 +902,7 @@ class EventListener implements Listener
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::PORKIFIED);
             if ($enchantment !== null && $entity instanceof PigProjectile !== true) {
                 $nbt = Entity::createBaseNBT($entity, $damager->getDirectionVector(), $entity->yaw, $entity->pitch);
-                $pig = Entity::createEntity("PigProjectile", $event->getEntity()->getLevel(), $nbt, $event->getEntity(), isset($entity->placeholder) ? $entity->placeholder : false, $enchantment->getLevel());
+                $pig = Entity::createEntity("PigProjectile", $damager->getLevel(), $nbt, $damager, isset($entity->placeholder) ? $entity->placeholder : false, $enchantment->getLevel());
                 $pig->setMotion($pig->getMotion()->multiply($event->getForce()));
                 $pig->spawnToAll();
                 $entity->close();

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -1128,14 +1128,14 @@ class EventListener implements Listener
                 }
                 if ($event instanceof EntityDamageByEntityEvent) {
                     $damager = $event->getDamager();
-                    if($damager instanceof Living){
-                        foreach($entity->getArmorInventory()->getContents() as $slot => $armor){
+                    if ($damager instanceof Living) {
+                        foreach ($entity->getArmorInventory()->getContents() as $slot => $armor) {
                             $enchantment = $armor->getEnchantment(CustomEnchantsIds::MOLTEN);
-                            if($enchantment !== null){
+                            if ($enchantment !== null) {
                                 $this->plugin->getServer()->getScheduler()->scheduleDelayedTask(new MoltenTask($this->plugin, $damager, $enchantment->getLevel()), 1);
                             }
                             $enchantment = $armor->getEnchantment(CustomEnchantsIds::ENLIGHTED);
-                            if($enchantment !== null && $entity->hasEffect(Effect::REGENERATION) !== true){
+                            if ($enchantment !== null && $entity->hasEffect(Effect::REGENERATION) !== true) {
                                 $effect = Effect::getEffect(Effect::REGENERATION);
                                 $effect->setAmplifier($enchantment->getLevel());
                                 $effect->setDuration(60 * $enchantment->getLevel());
@@ -1143,7 +1143,7 @@ class EventListener implements Listener
                                 $entity->addEffect($effect);
                             }
                             $enchantment = $armor->getEnchantment(CustomEnchantsIds::HARDENED);
-                            if($enchantment !== null && $damager->hasEffect(Effect::WEAKNESS) !== true){
+                            if ($enchantment !== null && $damager->hasEffect(Effect::WEAKNESS) !== true) {
                                 $effect = Effect::getEffect(Effect::WEAKNESS);
                                 $effect->setAmplifier($enchantment->getLevel());
                                 $effect->setDuration(60 * $enchantment->getLevel());
@@ -1151,7 +1151,7 @@ class EventListener implements Listener
                                 $damager->addEffect($effect);
                             }
                             $enchantment = $armor->getEnchantment(CustomEnchantsIds::POISONED);
-                            if($enchantment !== null && $damager->hasEffect(Effect::POISON) !== true){
+                            if ($enchantment !== null && $damager->hasEffect(Effect::POISON) !== true) {
                                 $effect = Effect::getEffect(Effect::POISON);
                                 $effect->setAmplifier($enchantment->getLevel());
                                 $effect->setDuration(60 * $enchantment->getLevel());
@@ -1159,7 +1159,7 @@ class EventListener implements Listener
                                 $damager->addEffect($effect);
                             }
                             $enchantment = $armor->getEnchantment(CustomEnchantsIds::FROZEN);
-                            if($enchantment !== null && $damager->hasEffect(Effect::SLOWNESS) !== true){
+                            if ($enchantment !== null && $damager->hasEffect(Effect::SLOWNESS) !== true) {
                                 $effect = Effect::getEffect(Effect::SLOWNESS);
                                 $effect->setAmplifier($enchantment->getLevel());
                                 $effect->setDuration(60 * $enchantment->getLevel());
@@ -1167,7 +1167,7 @@ class EventListener implements Listener
                                 $damager->addEffect($effect);
                             }
                             $enchantment = $armor->getEnchantment(CustomEnchantsIds::REVULSION);
-                            if($enchantment !== null && $damager->hasEffect(Effect::NAUSEA) !== true){
+                            if ($enchantment !== null && $damager->hasEffect(Effect::NAUSEA) !== true) {
                                 $effect = Effect::getEffect(Effect::NAUSEA);
                                 $effect->setAmplifier(0);
                                 $effect->setDuration(20 * $enchantment->getLevel());
@@ -1175,7 +1175,7 @@ class EventListener implements Listener
                                 $damager->addEffect($effect);
                             }
                             $enchantment = $armor->getEnchantment(CustomEnchantsIds::CURSED);
-                            if($enchantment !== null && $damager->hasEffect(Effect::WITHER) !== true){
+                            if ($enchantment !== null && $damager->hasEffect(Effect::WITHER) !== true) {
                                 $effect = Effect::getEffect(Effect::WITHER);
                                 $effect->setAmplifier($enchantment->getLevel());
                                 $effect->setDuration(60 * $enchantment->getLevel());
@@ -1183,22 +1183,22 @@ class EventListener implements Listener
                                 $damager->addEffect($effect);
                             }
                             $enchantment = $armor->getEnchantment(CustomEnchantsIds::DRUNK);
-                            if($enchantment !== null){
-                                if(!$damager->hasEffect(Effect::SLOWNESS)){
+                            if ($enchantment !== null) {
+                                if (!$damager->hasEffect(Effect::SLOWNESS)) {
                                     $effect = Effect::getEffect(Effect::SLOWNESS);
                                     $effect->setAmplifier($enchantment->getLevel());
                                     $effect->setDuration(60 * $enchantment->getLevel());
                                     $effect->setVisible(false);
                                     $damager->addEffect($effect);
                                 }
-                                if(!$damager->hasEffect(Effect::MINING_FATIGUE)){
+                                if (!$damager->hasEffect(Effect::MINING_FATIGUE)) {
                                     $effect = Effect::getEffect(Effect::MINING_FATIGUE);
                                     $effect->setAmplifier($enchantment->getLevel());
                                     $effect->setDuration(60 * $enchantment->getLevel());
                                     $effect->setVisible(false);
                                     $damager->addEffect($effect);
                                 }
-                                if(!$damager->hasEffect(Effect::NAUSEA)){
+                                if (!$damager->hasEffect(Effect::NAUSEA)) {
                                     $effect = Effect::getEffect(Effect::NAUSEA);
                                     $effect->setAmplifier(0);
                                     $effect->setDuration(60 * $enchantment->getLevel());
@@ -1207,8 +1207,8 @@ class EventListener implements Listener
                                 }
                             }
                             $enchantment = $armor->getEnchantment(CustomEnchantsIds::CLOAKING);
-                            if($enchantment !== null){
-                                if((!isset($this->plugin->cloakingcd[$entity->getLowerCaseName()]) || time() > $this->plugin->cloakingcd[$entity->getLowerCaseName()]) && $entity->hasEffect(Effect::INVISIBILITY)){
+                            if ($enchantment !== null) {
+                                if ((!isset($this->plugin->cloakingcd[$entity->getLowerCaseName()]) || time() > $this->plugin->cloakingcd[$entity->getLowerCaseName()]) && $entity->hasEffect(Effect::INVISIBILITY)) {
                                     $this->plugin->cloakingcd[$entity->getLowerCaseName()] = time() + 10;
                                     $effect = Effect::getEffect(Effect::INVISIBILITY);
                                     $effect->setAmplifier(0);
@@ -1219,26 +1219,26 @@ class EventListener implements Listener
                                 }
                             }
                             $enchantment = $armor->getEnchantment(CustomEnchantsIds::ANTIKNOCKBACK);
-                            if($enchantment !== null){
+                            if ($enchantment !== null) {
                                 $event->setKnockBack($event->getKnockBack() - ($event->getKnockBack() / $antikb));
                                 $antikb--;
                             }
-                            if($damager instanceof Player){
+                            if ($damager instanceof Player) {
                                 $enchantment = $armor->getEnchantment(CustomEnchantsIds::ARMORED);
-                                if($enchantment !== null){
-                                    if($damager->getInventory()->getItemInHand()->isSword()){
+                                if ($enchantment !== null) {
+                                    if ($damager->getInventory()->getItemInHand()->isSword()) {
                                         $event->setDamage($damage - ($damage * 0.2 * $enchantment->getLevel()));
                                     }
                                 }
                                 $enchantment = $armor->getEnchantment(CustomEnchantsIds::TANK);
-                                if($enchantment !== null){
-                                    if($damager->getInventory()->getItemInHand()->isAxe()){
+                                if ($enchantment !== null) {
+                                    if ($damager->getInventory()->getItemInHand()->isAxe()) {
                                         $event->setDamage($damage - ($damage * 0.2 * $enchantment->getLevel()));
                                     }
                                 }
                                 $enchantment = $armor->getEnchantment(CustomEnchantsIds::HEAVY);
-                                if($enchantment !== null){
-                                    if($damager->getInventory()->getItemInHand()->getId() == Item::BOW){
+                                if ($enchantment !== null) {
+                                    if ($damager->getInventory()->getItemInHand()->getId() == Item::BOW) {
                                         $event->setDamage($damage - ($damage * 0.2 * $enchantment->getLevel()));
                                     }
                                 }

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -880,7 +880,7 @@ class EventListener implements Listener
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::PLACEHOLDER);
             if ($enchantment !== null) {
                 $nbt = Entity::createBaseNBT($entity, $damager->getDirectionVector(), $entity->yaw, $entity->pitch);
-                $newentity = Entity::createEntity("VolleyArrow", $damager->getLevel(), $nbt, $damager, $entity->isCritical(), true, false);
+                $newentity = new VolleyArrow($damager->getLevel(), $nbt, $damager, $entity->isCritical(), true, false);
                 $newentity->setMotion($newentity->getMotion()->multiply($event->getForce()));
                 $newentity->spawnToAll();
                 $entity->close();

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -42,7 +42,6 @@ use pocketmine\event\player\PlayerMoveEvent;
 use pocketmine\event\player\PlayerQuitEvent;
 use pocketmine\event\player\PlayerToggleSneakEvent;
 use pocketmine\event\server\DataPacketReceiveEvent;
-use pocketmine\inventory\ArmorInventory;
 use pocketmine\inventory\transaction\action\SlotChangeAction;
 use pocketmine\item\Item;
 use pocketmine\level\particle\FlameParticle;

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -911,7 +911,7 @@ class EventListener implements Listener
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::WITHERSKULL);
             if ($enchantment !== null && $entity instanceof WitherSkull !== true) {
                 $nbt = Entity::createBaseNBT($entity, $damager->getDirectionVector(), $entity->yaw, $entity->pitch);
-                $skull = Entity::createEntity("WitherSkull", $damager->getLevel(), $nbt, $damager);
+                $skull = Entity::createEntity("WitherSkull", $damager->getLevel(), $nbt, $damager, isset($entity->placeholder) ? $entity->placeholder : false, $enchantment->getLevel() > 1 ? true : false);
                 $skull->setMotion($skull->getMotion()->multiply($event->getForce()));
                 $skull->spawnToAll();
                 $entity->close();

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -3,9 +3,9 @@
 namespace PiggyCustomEnchants;
 
 use PiggyCustomEnchants\CustomEnchants\CustomEnchantsIds;
-use PiggyCustomEnchants\Entities\Fireball;
+use PiggyCustomEnchants\Entities\PiggyFireball;
 use PiggyCustomEnchants\Entities\PigProjectile;
-use PiggyCustomEnchants\Entities\WitherSkull;
+use PiggyCustomEnchants\Entities\PiggyWitherSkull;
 use PiggyCustomEnchants\Tasks\GoeyTask;
 use PiggyCustomEnchants\Tasks\GrapplingTask;
 use PiggyCustomEnchants\Tasks\HallucinationTask;
@@ -544,7 +544,7 @@ class EventListener implements Listener
                 $chance = 10 * $enchantment->getLevel();
                 $random = mt_rand(0, 100);
                 if ($random <= $chance) {
-                    $lightning = Entity::createEntity("Lightning", $entity->getLevel(), Entity::createBaseNBT($entity));
+                    $lightning = Entity::createEntity("PiggyLightning", $entity->getLevel(), Entity::createBaseNBT($entity));
                     $lightning->setOwningEntity($damager);
                     $lightning->spawnToAll();
                 }
@@ -886,9 +886,9 @@ class EventListener implements Listener
                 $entity = $newentity;
             }
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::BLAZE);
-            if ($enchantment !== null && $entity instanceof Fireball !== true) {
+            if ($enchantment !== null && $entity instanceof PiggyFireball !== true) {
                 $nbt = Entity::createBaseNBT($entity, $damager->getDirectionVector(), $entity->yaw, $entity->pitch);
-                $fireball = Entity::createEntity("Fireball", $damager->getLevel(), $nbt, $damager, isset($entity->placeholder) ? $entity->placeholder : false);
+                $fireball = Entity::createEntity("PiggyFireball", $damager->getLevel(), $nbt, $damager, isset($entity->placeholder) ? $entity->placeholder : false);
                 $fireball->setMotion($fireball->getMotion()->multiply($event->getForce()));
                 $fireball->spawnToAll();
                 $entity->close();
@@ -904,9 +904,9 @@ class EventListener implements Listener
                 $entity = $pig;
             }
             $enchantment = $damager->getInventory()->getItemInHand()->getEnchantment(CustomEnchantsIds::WITHERSKULL);
-            if ($enchantment !== null && $entity instanceof WitherSkull !== true) {
+            if ($enchantment !== null && $entity instanceof PiggyWitherSkull !== true) {
                 $nbt = Entity::createBaseNBT($entity, $damager->getDirectionVector(), $entity->yaw, $entity->pitch);
-                $skull = Entity::createEntity("WitherSkull", $damager->getLevel(), $nbt, $damager, isset($entity->placeholder) ? $entity->placeholder : false, $enchantment->getLevel() > 1 ? true : false);
+                $skull = Entity::createEntity("PiggyWitherSkull", $damager->getLevel(), $nbt, $damager, isset($entity->placeholder) ? $entity->placeholder : false, $enchantment->getLevel() > 1 ? true : false);
                 $skull->setMotion($skull->getMotion()->multiply($event->getForce()));
                 $skull->spawnToAll();
                 $entity->close();
@@ -928,17 +928,17 @@ class EventListener implements Listener
                         $nbt = Entity::createBaseNBT($damager->add(0, $damager->getEyeHeight()), $damager->getDirectionVector(), $damager->yaw, $damager->pitch);
                         $projectile = Entity::createEntity("VolleyArrow", $damager->getLevel(), $nbt, $damager, $entity->isCritical(), false, true);
                     }
-                    if ($entity instanceof Fireball) {
+                    if ($entity instanceof PiggyFireball) {
                         $nbt = Entity::createBaseNBT($damager->add(0, $damager->getEyeHeight()), $damager->getDirectionVector(), $damager->yaw, $damager->pitch);
-                        $projectile = Entity::createEntity("Fireball", $damager->getLevel(), $nbt, $damager);
+                        $projectile = Entity::createEntity("PiggyFireball", $damager->getLevel(), $nbt, $damager);
                     }
                     if ($entity instanceof PigProjectile) {
                         $nbt = Entity::createBaseNBT($damager->add(0, $damager->getEyeHeight()), $damager->getDirectionVector(), $damager->yaw, $damager->pitch);
                         $projectile = Entity::createEntity("PigProjectile", $damager->getLevel(), $nbt, $damager, false, $entity->getPorkLevel());
                     }
-                    if ($entity instanceof WitherSkull) {
+                    if ($entity instanceof PiggyWitherSkull) {
                         $nbt = Entity::createBaseNBT($damager->add(0, $damager->getEyeHeight()), $damager->getDirectionVector(), $damager->yaw, $damager->pitch);
-                        $projectile = Entity::createEntity("WitherSkull", $damager->getLevel(), $nbt, $damager);
+                        $projectile = Entity::createEntity("PiggyWitherSkull", $damager->getLevel(), $nbt, $damager);
                     }
                     $projectile->setMotion($newDir->normalize()->multiply($entity->getMotion()->multiply($event->getForce())->length()));
                     if ($projectile->isOnFire()) {

--- a/src/PiggyCustomEnchants/EventListener.php
+++ b/src/PiggyCustomEnchants/EventListener.php
@@ -1022,7 +1022,7 @@ class EventListener implements Listener
                     if ($enchantment !== null) {
                         if ($event->getDamage() >= $entity->getHealth()) {
                             if ($enchantment->getLevel() > 1) {
-                                $entity->getArmorInventory()->setItem($slot,$this->plugin->addEnchantment($armor, $enchantment->getId(), $enchantment->getLevel() - 1));
+                                $entity->getArmorInventory()->setItem($slot, $this->plugin->addEnchantment($armor, $enchantment->getId(), $enchantment->getLevel() - 1));
                             }else{
                                 $entity->getArmorInventory()->setItem($slot, $this->plugin->removeEnchantment($armor, $enchantment));
                             }

--- a/src/PiggyCustomEnchants/Main.php
+++ b/src/PiggyCustomEnchants/Main.php
@@ -6,11 +6,6 @@ use PiggyCustomEnchants\Blocks\PiggyObsidian;
 use PiggyCustomEnchants\Commands\CustomEnchantCommand;
 use PiggyCustomEnchants\CustomEnchants\CustomEnchants;
 use PiggyCustomEnchants\CustomEnchants\CustomEnchantsIds;
-use PiggyCustomEnchants\Entities\Fireball;
-use PiggyCustomEnchants\Entities\Lightning;
-use PiggyCustomEnchants\Entities\PigProjectile;
-use PiggyCustomEnchants\Entities\VolleyArrow;
-use PiggyCustomEnchants\Entities\WitherSkull;
 use PiggyCustomEnchants\Tasks\AutoAimTask;
 use PiggyCustomEnchants\Tasks\CactusTask;
 use PiggyCustomEnchants\Tasks\ChickenTask;
@@ -250,11 +245,6 @@ class Main extends PluginBase
                 $this->getLogger()->info(TextFormat::RED . "Jetpack is currently disabled in the levels " . implode(", ", $this->jetpackDisabled) . ".");
             }
             BlockFactory::registerBlock(new PiggyObsidian(), true);
-            Entity::registerEntity(Fireball::class, true);
-            Entity::registerEntity(Lightning::class, true);
-            Entity::registerEntity(PigProjectile::class, true);
-            Entity::registerEntity(VolleyArrow::class, true);
-            Entity::registerEntity(WitherSkull::class, true);
             if (!ItemFactory::isRegistered(Item::ENCHANTED_BOOK)) { //Check if it isn't already registered by another plugin
                 ItemFactory::registerItem(new Item(Item::ENCHANTED_BOOK, 0, "Enchanted Book")); //This is a temporary fix for name being Unknown when given due to no implementation in PMMP. Will remove when implemented in PMMP
             }

--- a/src/PiggyCustomEnchants/Main.php
+++ b/src/PiggyCustomEnchants/Main.php
@@ -6,6 +6,11 @@ use PiggyCustomEnchants\Blocks\PiggyObsidian;
 use PiggyCustomEnchants\Commands\CustomEnchantCommand;
 use PiggyCustomEnchants\CustomEnchants\CustomEnchants;
 use PiggyCustomEnchants\CustomEnchants\CustomEnchantsIds;
+use PiggyCustomEnchants\Entities\Fireball;
+use PiggyCustomEnchants\Entities\Lightning;
+use PiggyCustomEnchants\Entities\PigProjectile;
+use PiggyCustomEnchants\Entities\VolleyArrow;
+use PiggyCustomEnchants\Entities\WitherSkull;
 use PiggyCustomEnchants\Tasks\AutoAimTask;
 use PiggyCustomEnchants\Tasks\CactusTask;
 use PiggyCustomEnchants\Tasks\ChickenTask;
@@ -80,6 +85,14 @@ class Main extends PluginBase
         "LIGHT_PURPLE" => TextFormat::LIGHT_PURPLE,
         "YELLOW" => TextFormat::YELLOW,
         "WHITE" => TextFormat::WHITE
+    ];
+
+    const PIGGY_ENTITIES = [
+        Fireball::class,
+        Lightning::class,
+        PigProjectile::class,
+        VolleyArrow::class,
+        WitherSkull::class
     ];
 
     public $berserkercd;
@@ -245,6 +258,10 @@ class Main extends PluginBase
                 $this->getLogger()->info(TextFormat::RED . "Jetpack is currently disabled in the levels " . implode(", ", $this->jetpackDisabled) . ".");
             }
             BlockFactory::registerBlock(new PiggyObsidian(), true);
+            foreach(self::PIGGY_ENTITIES as $piggyEntity) {
+                Entity::registerEntity($piggyEntity, true);
+            }
+
             if (!ItemFactory::isRegistered(Item::ENCHANTED_BOOK)) { //Check if it isn't already registered by another plugin
                 ItemFactory::registerItem(new Item(Item::ENCHANTED_BOOK, 0, "Enchanted Book")); //This is a temporary fix for name being Unknown when given due to no implementation in PMMP. Will remove when implemented in PMMP
             }


### PR DESCRIPTION
<!-- DO NOT REMOVE THIS:
failing to complete the required fields will result in the issue being closed due to insufficient information.
-->
Please make sure your pull request complies with these guidelines:
- * [ ] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title, like "Fix CustomEnchants::getName() must be..."

#### **What does the PR change?**
<!-- 
Does your Pull Request:
- resolve a bug? If so, link the issue with the PR and add explain what caused the issue.
- enhance the plugin? If so, explain what this adds, including why it should be added.
- translate the plugin? If so, refer to CONTRIBUTING.md for the guidelines of translating to another language.
-->
This PR will resolve issue https://github.com/DaPigGuy/PiggyCustomEnchants/issues/120 and update some API methods to be compatible with PocketMine-MP as of 1-26-2018.  Problem was due to conflicting entity registrations with the same NETWORK_ID (PigProjectile in PiggyCE and Pig in PureEntitiesX).  The problem was solved by updating the method in which projectiles are created in PiggyCE and removing entity registrations so as to avoid future conflicts with vanilla implementations of other entities (eg Lightning, Fireballs, WitherSkulls).  These changes are primarily found in `EventListener::checkBowEnchants` starting at 883 where `Entity::createEntity` is replaced with `new VolleyArrow`.  

#### **Testing Environment**
<!-- PHP and OS version required, pmmp build link required. -->
- PHP: 7.2
- PMMP: https://github.com/pmmp/PocketMine-MP/commit/de0741f727d745abbac1a80f761102b50e9c285a
- OS: Windows 10

#### **Extra Information**
<!-- Anything else we should know? -->

Demonstration VIdeo
https://youtu.be/v1EJQVGcYIQ

I can update formatting if need be.  This would be easier if there is a template file available for use with PHPStorm.
