### PR TITLE
Making new CE registering easier for lazy developers (like me)

### DIFF
--- a/src/DaPigGuy/PiggyCustomEnchants/enchants/CustomEnchant.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/enchants/CustomEnchant.php
@@ -23,6 +23,11 @@ class CustomEnchant extends Enchantment
     public $name = "";
     /** @var int */
     public $maxLevel = 5;
+    
+    /** @var int */
+    public $usageType = self::TYPE_HAND;
+    /** @var int */
+    public $itemType = self::ITEM_TYPE_WEAPON;
 
     /** @var array */
     public $cooldown;
@@ -72,7 +77,7 @@ class CustomEnchant extends Enchantment
      */
     public function getUsageType(): int
     {
-        return self::TYPE_HAND;
+        return $this->usageType;
     }
 
     /**
@@ -80,7 +85,7 @@ class CustomEnchant extends Enchantment
      */
     public function getItemType(): int
     {
-        return self::ITEM_TYPE_WEAPON;
+        return $this->itemType;
     }
 
     /**


### PR DESCRIPTION
People shouldn't have to make new CE classes just to select usage and item types in them :v

This should be added so developers adding new CEs using the API aren't required to make new classes for the CEs.

<!-- DO NOT REMOVE THIS:
failing to complete the required fields will result in the issue being closed due to insufficient information.
-->
Please make sure your pull request complies with these guidelines:
- * [ ] Use same formatting
- * [ ] Changes must have been tested on PMMP.
- * [ ] Unless it is a minor code modification, you must use an IDE.
- * [ ] Have a detailed title, like "Fix CustomEnchants::getName() must be..."

#### **What does the PR change?**
<!-- 
Does your Pull Request:
- resolve a bug? If so, link the issue with the PR and add explain what caused the issue.
- enhance the plugin? If so, explain what this adds, including why it should be added.
- translate the plugin? If so, refer to CONTRIBUTING.md for the guidelines of translating to another language.
-->

#### **Testing Environment**
<!-- PHP and OS version required, pmmp build link required. -->
- PHP: 7.2
- PMMP: 3.9.5
- OS: Idk ;-;

#### **Extra Information**
<!-- Anything else we should know? -->
