### PR TITLE
Fix PiggyCustomEnchantsShop

### DIFF
--- a/src/DaPigGuy/PiggyCustomEnchants/CustomEnchantManager.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/CustomEnchantManager.php
@@ -275,7 +275,7 @@ class CustomEnchantManager
     public static function getEnchantmentByName(string $name): ?CustomEnchant
     {
         foreach (self::$enchants as $enchant) {
-            if (strtolower(str_replace(" ", "", $enchant->getName())) === strtolower($name)) return $enchant;
+            if (strtolower(str_replace(" ", "", $enchant->getName())) === strtolower(str_replace(" ","", $name))) return $enchant;
         }
         return null;
     }

--- a/src/DaPigGuy/PiggyCustomEnchants/CustomEnchantManager.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/CustomEnchantManager.php
@@ -275,7 +275,7 @@ class CustomEnchantManager
     public static function getEnchantmentByName(string $name): ?CustomEnchant
     {
         foreach (self::$enchants as $enchant) {
-            if (strtolower(str_replace(" ", "", $enchant->getName())) === strtolower(str_replace(" ","", $name))) return $enchant;
+            if (strtolower(str_replace(" ", "", $enchant->getName())) === strtolower(str_replace(" ", "", $name))) return $enchant;
         }
         return null;
     }


### PR DESCRIPTION
<!-- DO NOT REMOVE THIS:
failing to complete the required fields will result in the issue being closed due to insufficient information.
-->
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title, like "Fix CustomEnchants::getName() must be..."

#### **What does the PR change?**
Fix's issue with PiggyCEShop attempting to get enchant with spaces in where here it only removes spaces from one side of the check.
-->

#### **Testing Environment**
<!-- PHP and OS version required, pmmp build link required. -->
- PHP: 7.3
- PMMP: 3.11.1
- OS: Windows+Linux

#### **Extra Information**
Feel free to trace my issue, add any enchant with a space in shop and try /ceshop it will fail.
