### PR TITLE
Fix duplication bug in TickEnchantmentsTask

### DIFF
--- a/src/DaPigGuy/PiggyCustomEnchants/tasks/TickEnchantmentsTask.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/tasks/TickEnchantmentsTask.php
@@ -69,7 +69,7 @@ class TickEnchantmentsTask extends Task
                 }
             }
             foreach ($player->getArmorInventory()->getContents() as $slot => $content) {
-                if ($content->getNamedTagEntry("PiggyCEItemVersion") === null && count($content->getEnchantments()) > 0) $player->getInventory()->setItem($slot, $this->cleanOldItems($content));
+                if ($content->getNamedTagEntry("PiggyCEItemVersion") === null && count($content->getEnchantments()) > 0) $player->getArmorInventory()->setItem($slot, $this->cleanOldItems($content));
                 foreach ($content->getEnchantments() as $enchantmentInstance) {
                     $enchantment = $enchantmentInstance->getType();
                     if ($enchantment instanceof CustomEnchant && $enchantment->canTick()) {


### PR DESCRIPTION
<!-- DO NOT REMOVE THIS:
failing to complete the required fields will result in the issue being closed due to insufficient information.
-->
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title, like "Fix CustomEnchants::getName() must be..."

#### **What does the PR change?**
<!-- 
Does your Pull Request:
- resolve a bug? If so, link the issue with the PR and add explain what caused the issue.
- enhance the plugin? If so, explain what this adds, including why it should be added.
- translate the plugin? If so, refer to CONTRIBUTING.md for the guidelines of translating to another language.
-->
[Here](https://github.com/DaPigGuy/PiggyCustomEnchants/blob/master/src/DaPigGuy/PiggyCustomEnchants/tasks/TickEnchantmentsTask.php#L72) it should be getArmorInventory() and not getInventory() since you are iterating over the player's armor inventory.
#### **Testing Environment**
<!-- PHP and OS version required, pmmp build link required. -->
- PHP: 7.3.11
- PMMP: [3.11.2](https://github.com/pmmp/PocketMine-MP/releases/tag/3.11.2)
- OS: macOS 10.14.6

#### **Extra Information**
<!-- Anything else we should know? -->
This mistake caused a duplication bug to happen in AdvancedKits.