### PR TITLE
Fix forcefield and Smelting bug

### DIFF
--- a/src/DaPigGuy/PiggyCustomEnchants/EventListener.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/EventListener.php
@@ -33,7 +33,7 @@ use pocketmine\event\player\cheat\PlayerIllegalMoveEvent;
 use pocketmine\event\player\PlayerDeathEvent;
 use pocketmine\event\player\PlayerInteractEvent;
 use pocketmine\event\player\PlayerItemHeldEvent;
-use pocketmine\event\player\PlayerJoinEvent;
+use pocketmine\event\player\PlayerLoginEvent;
 use pocketmine\event\player\PlayerKickEvent;
 use pocketmine\event\player\PlayerMoveEvent;
 use pocketmine\event\player\PlayerQuitEvent;
@@ -335,9 +335,9 @@ class EventListener implements Listener
     }
 
     /**
-     * @param PlayerJoinEvent $event
+     * @param PlayerLoginEvent $event
      */
-    public function onJoin(PlayerJoinEvent $event): void
+    public function onJoin(PlayerLoginEvent $event): void
     {
         $player = $event->getPlayer();
         foreach ($player->getInventory()->getItemInHand()->getEnchantments() as $enchantmentInstance) {

--- a/src/DaPigGuy/PiggyCustomEnchants/enchants/tools/SmeltingEnchant.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/enchants/tools/SmeltingEnchant.php
@@ -13,6 +13,7 @@ use pocketmine\inventory\Inventory;
 use pocketmine\item\Item;
 use pocketmine\Player;
 use ReflectionException;
+use function array_search;
 
 /**
  * Class SmeltingEnchant

--- a/src/DaPigGuy/PiggyCustomEnchants/enchants/tools/SmeltingEnchant.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/enchants/tools/SmeltingEnchant.php
@@ -67,7 +67,8 @@ class SmeltingEnchant extends ReactiveEnchantment
     {
         if ($event instanceof BlockBreakEvent) {
             $event->setDrops(array_map(function (Item $item) {
-                if (($key = array_search($item, $this->inputTable)) || ($key = array_search($item->setDamage(-1), $this->inputTable))) {
+                $copy = clone $item;
+                if (($key = array_search($copy, $this->inputTable)) || ($key = array_search($copy->setDamage(-1), $this->inputTable))) {
                     return $this->outputTable[$key];
                 }
                 return $item;


### PR DESCRIPTION
<!-- DO NOT REMOVE THIS:
failing to complete the required fields will result in the issue being closed due to insufficient information.
-->
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title, like "Fix CustomEnchants::getName() must be..."

#### **What does the PR change?**
<!-- 
Does your Pull Request:
- resolve a bug? Fix #235 
- enhance the plugin? If so, explain what this adds, including why it should be added.
- translate the plugin? If so, refer to CONTRIBUTING.md for the guidelines of translating to another language.
-->
- resolve a bug? 
    - Fix #235.
    - fixed an issue where breaking a lapis_ore would return a Dye with damage -1

#### **Testing Environment**
<!-- PHP and OS version required, pmmp build link required. -->
- PHP: 7.3
- PMMP: 3.11.2
- OS: Ubuntu18.04lts/W10Pro

#### **Extra Information**
<!-- Anything else we should know? -->
