### PR TITLE
fix jackpot bug

### DIFF
--- a/src/DaPigGuy/PiggyCustomEnchants/enchants/tools/pickaxe/JackpotEnchant.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/enchants/tools/pickaxe/JackpotEnchant.php
@@ -51,7 +51,7 @@ class JackpotEnchant extends ReactiveEnchantment
     {
         if ($event instanceof BlockBreakEvent) {
             $key = array_search($event->getBlock()->getId(), self::ORE_TIERS);
-            if ($key !== null) {
+            if ($key != null) {
                 if (isset(self::ORE_TIERS[$key + 1])) {
                     $drops = $event->getDrops();
                     foreach ($drops as $k => $drop) {


### PR DESCRIPTION
<!-- DO NOT REMOVE THIS:
failing to complete the required fields will result in the issue being closed due to insufficient information.
-->
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title, like "Fix CustomEnchants::getName() must be..."

#### **What does the PR change?**
<!-- 
Does your Pull Request:
- resolve a bug? If so, link the issue with the PR and add explain what caused the issue.
- enhance the plugin? If so, explain what this adds, including why it should be added.
- translate the plugin? If so, refer to CONTRIBUTING.md for the guidelines of translating to another language.
-->
- resolve a bug? This PR solves a bug that let you get iron from mining stone with a jackpot pickaxe.

#### **Testing Environment**
<!-- PHP and OS version required, pmmp build link required. -->
- PHP: 7.3
- PMMP: 3.11.3
- OS: Ubuntu18.04lts/W10

#### **Extra Information**
<!-- Anything else we should know? -->
