### PR TITLE
EventListener: Fix packet item returning ItemStackWrapper

### DIFF
--- a/src/DaPigGuy/PiggyCustomEnchants/EventListener.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/EventListener.php
@@ -94,11 +94,11 @@ class EventListener implements Listener
     {
         $packet = $event->getPacket();
         if ($packet instanceof InventorySlotPacket) {
-            Utils::displayEnchants($packet->item);
+            Utils::displayEnchants($packet->item->getItemStack());
         }
         if ($packet instanceof InventoryContentPacket) {
-            foreach ($packet->items as $key => $item) {
-                $packet->items[$key] = Utils::displayEnchants($item);
+            foreach ($packet->items as $item) {
+                Utils::displayEnchants($item->getItemStack());
             }
         }
     }


### PR DESCRIPTION
<!-- Failure to complete the required fields will result in the issue being closed. -->
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title.

#### **What does the PR change?**
This pull request fixes this issue https://github.com/DaPigGuy/PiggyCustomEnchants/issues/303. The issue was caused by the most recent PocketMine 3.14.0 release, where both **InventorySlotPacket->item** and **InventoryContentPacket->items** were returning ItemStackWrapper instances (instead of Items).

#### **Testing Environment**
- PHP: 7.3
- PMMP: 3.14.0
- OS: Deepin (Debian)

#### **Extra Information**