### PR TITLE
Fixed enchantments reacting when explicitly not wanting to

### DIFF
--- a/src/DaPigGuy/PiggyCustomEnchants/enchants/traits/ReactiveTrait.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/enchants/traits/ReactiveTrait.php
@@ -41,8 +41,9 @@ trait ReactiveTrait
         if (isset($perWorldDisabledEnchants[$player->getWorld()->getFolderName()]) && in_array(strtolower($this->name), $perWorldDisabledEnchants[$player->getWorld()->getFolderName()])) return;
         if ($this->getCooldown($player) > 0) return;
         if ($event instanceof EntityDamageByEntityEvent) {
-            if ($event->getEntity() === $player && $event->getDamager() !== $player && $this->shouldReactToDamage()) return;
-            if ($event->getEntity() !== $player && $this->shouldReactToDamaged()) return;
+            if ($event->getEntity() === $player) {
+                if ($event->getDamager() !== $player && !$this->shouldReactToDamaged()) return;
+            } elseif (!$this->shouldReactToDamage()) return;
         }
         if (mt_rand(0 * 100000, 100 * 100000) / 100000 <= $this->getChance($player, $level)) {
             $this->react($player, $item, $inventory, $slot, $event, $level, $stack);


### PR DESCRIPTION
<!-- Failure to complete the required fields will result in the issue being closed. -->
Please make sure your pull request complies with these guidelines:
- * [x] Use same formatting
- * [x] Changes must have been tested on PMMP.
- * [x] Unless it is a minor code modification, you must use an IDE.
- * [x] Have a detailed title.

#### **What does the PR change?**
<!-- 
Does your Pull Request:
- resolve a bug? If so, link the issue with the PR and add explain what caused the issue.
- enhance the plugin? If so, explain what this adds, including why it should be added.
-->
Fixed a bug in which an enchantment reacts when explicitly not wanting to with the `shouldReactTo…()` methods.
#### **Testing Environment**
<!-- PHP and OS version required, pmmp build link required. -->
- PHP: 8.0.19
- PMMP: 4.5.0
- OS: Linux

#### **Extra Information**
<!-- Anything else we should know? -->
None