### PR TITLE
Patch 1

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: PiggyCustomEnchants
 main: DaPigGuy\PiggyCustomEnchants\PiggyCustomEnchants
 version: 3.0.8
 api: 4.2.0
-mcpe-protocol: [ 554, 557 ]
+mcpe-protocol: [ 554, 557, 560 ]
 load: POSTWORLD
 author: DaPigGuy
 website: "https://github.com/DaPigGuy/PiggyCustomEnchants/"

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: PiggyCustomEnchants
 main: DaPigGuy\PiggyCustomEnchants\PiggyCustomEnchants
 version: 3.0.7
 api: 4.2.0
-mcpe-protocol: [ 554 ]
+mcpe-protocol: [ 554, 557 ]
 load: POSTWORLD
 author: DaPigGuy
 website: "https://github.com/DaPigGuy/PiggyCustomEnchants/"

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: PiggyCustomEnchants
 main: DaPigGuy\PiggyCustomEnchants\PiggyCustomEnchants
 version: 3.0.8
 api: 4.2.0
-mcpe-protocol: [ 554, 557, 560 ]
+mcpe-protocol: [ 554, 557, 560, 567 ]
 load: POSTWORLD
 author: DaPigGuy
 website: "https://github.com/DaPigGuy/PiggyCustomEnchants/"

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: PiggyCustomEnchants
 main: DaPigGuy\PiggyCustomEnchants\PiggyCustomEnchants
 version: 3.0.8
 api: 4.2.0
-mcpe-protocol: [ 554, 557, 560, 567, 575, 579, 582 ]
+mcpe-protocol: [ 554, 557, 560, 567, 575, 579, 582, 594 ]
 load: POSTWORLD
 author: DaPigGuy
 website: "https://github.com/DaPigGuy/PiggyCustomEnchants/"

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: PiggyCustomEnchants
 main: DaPigGuy\PiggyCustomEnchants\PiggyCustomEnchants
 version: 3.0.8
 api: 4.2.0
-mcpe-protocol: [ 554, 557, 560, 567, 575 ]
+mcpe-protocol: [ 554, 557, 560, 567, 575, 579, 582 ]
 load: POSTWORLD
 author: DaPigGuy
 website: "https://github.com/DaPigGuy/PiggyCustomEnchants/"

--- a/plugin.yml
+++ b/plugin.yml
@@ -2,7 +2,7 @@ name: PiggyCustomEnchants
 main: DaPigGuy\PiggyCustomEnchants\PiggyCustomEnchants
 version: 3.0.8
 api: 4.2.0
-mcpe-protocol: [ 554, 557, 560, 567 ]
+mcpe-protocol: [ 554, 557, 560, 567, 575 ]
 load: POSTWORLD
 author: DaPigGuy
 website: "https://github.com/DaPigGuy/PiggyCustomEnchants/"

--- a/plugin.yml
+++ b/plugin.yml
@@ -1,6 +1,6 @@
 name: PiggyCustomEnchants
 main: DaPigGuy\PiggyCustomEnchants\PiggyCustomEnchants
-version: 3.0.7
+version: 3.0.8
 api: 4.2.0
 mcpe-protocol: [ 554, 557 ]
 load: POSTWORLD

--- a/src/DaPigGuy/PiggyCustomEnchants/enchants/armor/OverloadEnchant.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/enchants/armor/OverloadEnchant.php
@@ -27,7 +27,10 @@ class OverloadEnchant extends ToggleableEnchantment
 
     public function toggle(Player $player, Item $item, Inventory $inventory, int $slot, int $level, bool $toggle): void
     {
-        $player->setMaxHealth($player->getMaxHealth() + $this->extraData["multiplier"] * $level * ($toggle ? 1 : -1));
-        $player->setHealth($player->getHealth() * ($player->getMaxHealth() / ($player->getMaxHealth() - $this->extraData["multiplier"] * $level * ($toggle ? 1 : -1))));
+        $maxHealth = $player->getMaxHealth() + $this->extraData["multiplier"] * $level * ($toggle ? 1 : -1);
+        $health = $player->getHealth() * ($player->getMaxHealth() / ($player->getMaxHealth() - $this->extraData["multiplier"] * $level * ($toggle ? 1 : -1)));
+
+        $player->setMaxHealth(max($maxHealth, 1));
+        $player->setHealth(max($health, 0));
     }
 }

--- a/src/DaPigGuy/PiggyCustomEnchants/enchants/armor/ShieldedEnchant.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/enchants/armor/ShieldedEnchant.php
@@ -38,7 +38,11 @@ class ShieldedEnchant extends ToggleableEnchantment
             }
         }
         $player->getEffects()->remove(VanillaEffects::RESISTANCE());
-        $player->getEffects()->add(new EffectInstance(VanillaEffects::RESISTANCE(), 2147483647, $this->getStack($player) - 1, false));
+
+        $amplifier = $this->getStack($player) - 1;
+        if ($amplifier < 0) $amplifier = 0;
+
+        $player->getEffects()->add(new EffectInstance(VanillaEffects::RESISTANCE(), 2147483647, $amplifier, false));
     }
 
     public function canEffectsStack(): bool

--- a/src/DaPigGuy/PiggyCustomEnchants/enchants/miscellaneous/ToggleableEffectEnchant.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/enchants/miscellaneous/ToggleableEffectEnchant.php
@@ -53,7 +53,8 @@ class ToggleableEffectEnchant extends ToggleableEnchantment
             }
         }
         $player->getEffects()->remove($this->effect);
-        $player->getEffects()->add(new EffectInstance($this->effect, 2147483647, $this->extraData["baseAmplifier"] + $this->extraData["amplifierMultiplier"] * $level, false));
+        $amplifier = $this->extraData["baseAmplifier"] + $this->extraData["amplifierMultiplier"] * $level;
+        $player->getEffects()->add(new EffectInstance($this->effect, 2147483647, min($amplifier, 255), false));
     }
 
     public function getUsageType(): int

--- a/src/DaPigGuy/PiggyCustomEnchants/enchants/traits/ReactiveTrait.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/enchants/traits/ReactiveTrait.php
@@ -41,8 +41,9 @@ trait ReactiveTrait
         if (isset($perWorldDisabledEnchants[$player->getWorld()->getFolderName()]) && in_array(strtolower($this->name), $perWorldDisabledEnchants[$player->getWorld()->getFolderName()])) return;
         if ($this->getCooldown($player) > 0) return;
         if ($event instanceof EntityDamageByEntityEvent) {
-            if ($event->getEntity() === $player && $event->getDamager() !== $player && $this->shouldReactToDamage()) return;
-            if ($event->getEntity() !== $player && $this->shouldReactToDamaged()) return;
+            if ($event->getEntity() === $player) {
+                if ($event->getDamager() !== $player && !$this->shouldReactToDamaged()) return;
+            } elseif (!$this->shouldReactToDamage()) return;
         }
         if (mt_rand(0 * 100000, 100 * 100000) / 100000 <= $this->getChance($player, $level)) {
             $this->react($player, $item, $inventory, $slot, $event, $level, $stack);

--- a/src/DaPigGuy/PiggyCustomEnchants/entities/PiggyLightning.php
+++ b/src/DaPigGuy/PiggyCustomEnchants/entities/PiggyLightning.php
@@ -39,7 +39,9 @@ class PiggyLightning extends Entity
             }
         }
         if ($this->getWorld()->getBlock($this->location)->canBeFlowedInto() && CustomEnchantManager::getPlugin()->getConfig()->getNested("world-damage.lightning", false) === true) {
-            $this->getWorld()->setBlock($this->location, VanillaBlocks::FIRE());
+            if ($this->getWorld()->getMaxY() > $this->location->getY() && $this->getWorld()->getMinY() < $this->location->getY()) {
+                $this->getWorld()->setBlock($this->location, VanillaBlocks::FIRE());
+            } // otherwise OutOfBounds!
         }
         if ($this->age > 20) $this->flagForDespawn();
         return parent::entityBaseTick($tickDiff);


### PR DESCRIPTION
This one should fix the following error:

2022-09-23 [20:21:27.040] [Server thread/CRITICAL]: InvalidArgumentException: "Amplifier must be in range 0 - 255, got -2" (EXCEPTION) in "pmsrc/src/entity/effect/EffectInstance" at line 111
--- Stack trace ---
  #0 pmsrc/src/entity/effect/EffectInstance(44): pocketmine\entity\effect\EffectInstance->setAmplifier(int -2)
  #1 plugins/PiggyCustomEnchants.phar/src/DaPigGuy/PiggyCustomEnchants/enchants/armor/ShieldedEnchant(41): pocketmine\entity\effect\EffectInstance->__construct(object pocketmine\entity\effect\Effect#112565, int 2147483647, int -2, false)
  #2 plugins/PiggyCustomEnchants.phar/src/DaPigGuy/PiggyCustomEnchants/enchants/traits/ToggleTrait(38): DaPigGuy\PiggyCustomEnchants\enchants\armor\ShieldedEnchant->toggle(object pocketmine\player\Player#168705, object pocketmine\item\Armor#339263, object pocketmine\inventory\ArmorInventory#247753, int 1, int 1, false)
  #3 plugins/PiggyCustomEnchants.phar/src/DaPigGuy/PiggyCustomEnchants/enchants/traits/ToggleTrait(88): DaPigGuy\PiggyCustomEnchants\enchants\ToggleableEnchantment->onToggle(object pocketmine\player\Player#168705, object pocketmine\item\Armor#339263, object pocketmine\inventory\ArmorInventory#247753, int 1, int 1, false)
  #4 plugins/PiggyCustomEnchants.phar/src/DaPigGuy/PiggyCustomEnchants/EventListener(262): DaPigGuy\PiggyCustomEnchants\enchants\ToggleableEnchantment::attemptToggle(object pocketmine\player\Player#168705, object pocketmine\item\Armor#339263, object pocketmine\item\enchantment\EnchantmentInstance#312380, object pocketmine\inventory\ArmorInventory#247753, int 1, false)
  #5 pmsrc/src/event/RegisteredListener(60): DaPigGuy\PiggyCustomEnchants\EventListener->onQuit(object pocketmine\event\player\PlayerQuitEvent#175514)
  #6 pmsrc/src/event/Event(62): pocketmine\event\RegisteredListener->callEvent(object pocketmine\event\player\PlayerQuitEvent#175514)
  #7 pmsrc/src/player/Player(2100): pocketmine\event\Event->call()
  #8 pmsrc/src/network/mcpe/NetworkSession(576): pocketmine\player\Player->onPostDisconnect(string[17] client disconnect, null)
  #9 pmsrc/src/network/mcpe/NetworkSession(509): pocketmine\network\mcpe\NetworkSession->pocketmine\network\mcpe\{closure}()
  #10 pmsrc/src/network/mcpe/NetworkSession(578): pocketmine\network\mcpe\NetworkSession->tryDisconnect(object Closure#219421, string[17] client disconnect)
  #11 pmsrc/src/network/mcpe/raklib/RakLibInterface(141): pocketmine\network\mcpe\NetworkSession->onClientDisconnect(string[17] client disconnect)
  #12 pmsrc/vendor/pocketmine/raklib-ipc/src/RakLibToUserThreadMessageReceiver(75): pocketmine\network\mcpe\raklib\RakLibInterface->onClientDisconnect(int 439, string[17] client disconnect)
  #13 pmsrc/src/network/mcpe/raklib/RakLibInterface(112): raklib\server\ipc\RakLibToUserThreadMessageReceiver->handle(object pocketmine\network\mcpe\raklib\RakLibInterface#111043)
  #14 pmsrc/vendor/pocketmine/snooze/src/SleeperHandler(123): pocketmine\network\mcpe\raklib\RakLibInterface->pocketmine\network\mcpe\raklib\{closure}()
  #15 pmsrc/vendor/pocketmine/snooze/src/SleeperHandler(82): pocketmine\snooze\SleeperHandler->processNotifications()
  #16 pmsrc/src/Server(1703): pocketmine\snooze\SleeperHandler->sleepUntil(float 1663957287.0515)
  #17 pmsrc/src/Server(1063): pocketmine\Server->tickProcessor()
  #18 pmsrc/src/PocketMine(305): pocketmine\Server->__construct(object BaseClassLoader#3, object pocketmine\utils\MainLogger#2, string[34] /home/clientservers/server-283952/, string[42] /home/clientservers/server-283952/plugins/)
  #19 pmsrc/src/PocketMine(328): pocketmine\server()
  #20 pmsrc(11): require(string[71] phar:///home/serversoftwares/PocketMine_1.19.21.phar/src/PocketMine.php)
--- End of exception information ---
